### PR TITLE
Add today's date to bug report template version dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -7,6 +7,7 @@ body:
       label: Version
       options:
         - MVP
+        - 19th of December Reports
   - type: dropdown
     id: severity
     attributes:


### PR DESCRIPTION
I've used today's date under versions as an option, because I'm not sure what we're calling the next version!