### PR TITLE
Added all potential dates to bug versions in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -8,6 +8,11 @@ body:
       options:
         - MVP
         - 19th of December Reports
+        - 5th of January Reports
+        - 6th of January Reports
+        - 7th of January Reports
+        - 8th of January Reports
+        - 9th of January Reports
   - type: dropdown
     id: severity
     attributes:


### PR DESCRIPTION
I changed the bug report template to include all potential dates for submitting bugs for the rest of the project. E.g. If a bug's submitted today, we'll be able to choose "5th of January Reports" from the version dropdown inside the template.